### PR TITLE
test(sms): use unique reference name

### DIFF
--- a/src/lib/sms/SMSClient.ts
+++ b/src/lib/sms/SMSClient.ts
@@ -31,7 +31,7 @@ interface SendMessageInput {
   contactZipCode?: string;
 }
 
-interface SendingLocation {
+export interface SendingLocation {
   id: string;
   areaCodes: string[];
   center: string;


### PR DESCRIPTION
This allows multiple test suites to be run in parallel without deleting each others' sending
locations. The test for sendMessage still relies on all tests and test suites being run in
parallel, however. That will likely require a change to the numbers service to support test API
keys.