### PR TITLE
fix: surface GraphQL errors

### DIFF
--- a/src/lib/NumbersClient.ts
+++ b/src/lib/NumbersClient.ts
@@ -4,6 +4,7 @@ import ql from 'superagent-graphql';
 
 import { LookupClient } from './lookup/LookupClient';
 import { SMSClient } from './sms/SMSClient';
+import { raiseGqlErrors } from './util';
 
 export const DEFAULT_BASE_URL = 'https://numbers.assemble.live';
 
@@ -53,9 +54,9 @@ class NumbersClient {
    * @param variables variables matching your graphql query
    */
   rawGraphQLRequest = async (path: string, query, variables) => {
-    const response = await this._requestWrapper(path)().use(
-      ql(query, variables)
-    );
+    const response = await this._requestWrapper(path)()
+      .use(ql(query, variables))
+      .then(raiseGqlErrors);
     return response.body.data;
   };
 

--- a/src/lib/lookup/LookupClient.ts
+++ b/src/lib/lookup/LookupClient.ts
@@ -3,6 +3,7 @@ import ql from 'superagent-graphql';
 import { CREATE_REQUEST } from './queries';
 import { Request } from './Request';
 import { RequestFactoryWrapper, RequestFactory } from '../NumbersClient';
+import { raiseGqlErrors } from '../util';
 
 export const LOOKUP_GRAPHQL_PATH = '/lookup/graphql';
 
@@ -33,7 +34,9 @@ class LookupClient {
   }
 
   async createRequest() {
-    const response = await this._requestFactory().use(ql(CREATE_REQUEST));
+    const response = await this._requestFactory()
+      .use(ql(CREATE_REQUEST))
+      .then(raiseGqlErrors);
     return new Request({
       requestFactory: this._requestFactory,
       requestId: response.body.data.createRequest.request.id

--- a/src/lib/sms/SMSClient.ts
+++ b/src/lib/sms/SMSClient.ts
@@ -8,6 +8,7 @@ import {
   SEND_MESSAGE
 } from './queries';
 import { RequestFactoryWrapper, RequestFactory } from '../NumbersClient';
+import { raiseGqlErrors } from '../util';
 
 export const SMS_GRAPHQL_PATH = '/sms/graphql';
 
@@ -110,9 +111,9 @@ class SMSClient {
   createSendingLocation = async (
     args: CreateSendingLocationInput
   ): Promise<CreateSendingLocationResult> => {
-    const response = await this.request().use(
-      ql(CREATE_SENDING_LOCATION, args)
-    );
+    const response = await this.request()
+      .use(ql(CREATE_SENDING_LOCATION, args))
+      .then(raiseGqlErrors);
     return response.body;
   };
 
@@ -120,32 +121,34 @@ class SMSClient {
     id: string,
     patch: UpdateSendingLocationPatch
   ): Promise<UpdateSendingLocationResult> => {
-    const response = await this.request().use(
-      ql(UPDATE_SENDING_LOCATION, { id, patch })
-    );
+    const response = await this.request()
+      .use(ql(UPDATE_SENDING_LOCATION, { id, patch }))
+      .then(raiseGqlErrors);
     return response.body;
   };
 
   deleteSendingLocation = async (
     id: string
   ): Promise<DeleteSendingLocationResult> => {
-    const response = await this.request().use(
-      ql(DELETE_SENDING_LOCATION, { id })
-    );
+    const response = await this.request()
+      .use(ql(DELETE_SENDING_LOCATION, { id }))
+      .then(raiseGqlErrors);
     return response.body;
   };
 
   getSendingLocations = async (
     profileId: string
   ): Promise<GetSendingLocationsResult> => {
-    const response = await this.request().use(
-      ql(GET_SENDING_LOCATIONS, { profileId })
-    );
+    const response = await this.request()
+      .use(ql(GET_SENDING_LOCATIONS, { profileId }))
+      .then(raiseGqlErrors);
     return response.body;
   };
 
   sendMessage = async (args: SendMessageInput): Promise<SendMessageResult> => {
-    const response = await this.request().use(ql(SEND_MESSAGE, args));
+    const response = await this.request()
+      .use(ql(SEND_MESSAGE, args))
+      .then(raiseGqlErrors);
     return response.body;
   };
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,0 +1,22 @@
+import { Response } from 'superagent';
+
+export class SwitchboardError extends Error {
+  errors: any[];
+
+  constructor(errors: any[] = []) {
+    const errorText = errors
+      .map(err => `  - message: ${err.message}\n  path: ${err.path.join('::')}`)
+      .join('\n');
+    super(`Encountered Switchboard error(s):\n${errorText}`);
+    this.errors = errors;
+  }
+}
+
+export const raiseGqlErrors = (res: Response): Response => {
+  const { errors = [] } = res.body;
+  if (errors.length > 0) {
+    throw new SwitchboardError(errors);
+  }
+
+  return res;
+};


### PR DESCRIPTION
GraphQL errors are not currently surfaced. This means that the end application only gets generic errors of the type `TypeError: Cannot read property 'addPhoneNumbersToRequest' of null` when the GraphQL response's body has `errors` instead of `data`. This makes debugging the issue much more difficult.

Using this brute-force `.then(raiseGqlErrors)` approach because `superagent` plugins do not seem to support a response "middleware" approach. I tried using `superagent-intercept` but that did not allow raising an error from within the handler. I could find no documentation on writing `superagent` plugins and my own attempts were unsuccessful.

