### PR TITLE
tests: fix test suite

### DIFF
--- a/src/lib/sms/SMSClient.spec.ts
+++ b/src/lib/sms/SMSClient.spec.ts
@@ -26,6 +26,7 @@ const {
 } = process.env;
 const TEST_CENTER = '11205';
 const OTHER_AREA_CODE = '212';
+const PURCHASING_STRATEGY = 'same-state-by-distance';
 const randomInt = Math.round(Math.random() * 1000);
 const LOCATION_REFERENCE_NAME = `TestLocation_${Date.now()}_${randomInt}`;
 
@@ -41,6 +42,7 @@ test('can create sending location', async t => {
   const response = await client.createSendingLocation({
     profileId: TEST_PROFILE_ID,
     referenceName: LOCATION_REFERENCE_NAME,
+    purchasingStrategy: PURCHASING_STRATEGY,
     center: TEST_CENTER
   });
 

--- a/src/lib/sms/SMSClient.spec.ts
+++ b/src/lib/sms/SMSClient.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import request from 'superagent';
 
-import { SMSClient, SendingLocation } from './SMSClient';
+import { SMSClient } from './SMSClient';
 import { RequestFactoryWrapper, DEFAULT_BASE_URL } from '../NumbersClient';
 
 if (!process.env.TEST_API_KEY) {
@@ -19,19 +19,11 @@ if (!process.env.TEST_DESTINATION_PHONE_NUMBER) {
   process.exit(1);
 }
 
-const {
-  TEST_API_KEY,
-  TEST_PROFILE_ID,
-  TEST_DESTINATION_PHONE_NUMBER
-} = process.env;
+const { TEST_API_KEY, TEST_PROFILE_ID } = process.env;
 const TEST_CENTER = '11205';
-const OTHER_AREA_CODE = '212';
 const PURCHASING_STRATEGY = 'SAME_STATE_BY_DISTANCE';
 const randomInt = Math.round(Math.random() * 1000);
 const LOCATION_REFERENCE_NAME = `TestLocation_${Date.now()}_${randomInt}`;
-
-const locationNamePredicate = (location: SendingLocation) =>
-  location.referenceName === LOCATION_REFERENCE_NAME;
 
 const REQUEST: RequestFactoryWrapper = path => () =>
   request.post(`${DEFAULT_BASE_URL}${path}`).set('token', TEST_API_KEY);
@@ -52,56 +44,5 @@ test('can create sending location', async t => {
       response.data.createSendingLocation.sendingLocation.areaCodes
     ),
     true
-  );
-});
-
-test('can fetch and edit sending location', async t => {
-  const response = await client.getSendingLocations(TEST_PROFILE_ID);
-  const sendingLocations = response.data.sendingLocations.nodes;
-  t.is(Array.isArray(sendingLocations), true);
-
-  const sendingLocation = sendingLocations.find(locationNamePredicate);
-  const sendingLocationId = sendingLocation.id;
-  t.is(typeof sendingLocationId, 'string');
-
-  const areaCodes = sendingLocation.areaCodes;
-  areaCodes.push(OTHER_AREA_CODE);
-  const updateResonse = await client.updateSendingLocation(sendingLocationId, {
-    areaCodes
-  });
-
-  t.deepEqual(
-    updateResonse.data.updateSendingLocation.sendingLocation.areaCodes,
-    areaCodes
-  );
-});
-
-test('can delete sending locations', async t => {
-  const response = await client.getSendingLocations(TEST_PROFILE_ID);
-  const { nodes: sendingLocations } = response.data.sendingLocations;
-  const sendingLocation = sendingLocations.find(locationNamePredicate);
-  const sendingLocationId = sendingLocation.id;
-
-  const deleteResponse = await client.deleteSendingLocation(sendingLocationId);
-  t.is(
-    deleteResponse.data.deleteSendingLocation.sendingLocation.id,
-    sendingLocationId
-  );
-});
-
-test('can send messages', async t => {
-  const response = await client.sendMessage({
-    to: TEST_DESTINATION_PHONE_NUMBER,
-    profileId: TEST_PROFILE_ID,
-    body: 'hello! the test was run.'
-  });
-
-  /**
-   * Failure is a success for the client
-   * - it failed because we deleted the sending location in the previous test
-   */
-  t.is(
-    response.errors[0].message,
-    'Must create a sending location before sending messages'
   );
 });

--- a/src/lib/sms/SMSClient.spec.ts
+++ b/src/lib/sms/SMSClient.spec.ts
@@ -26,7 +26,7 @@ const {
 } = process.env;
 const TEST_CENTER = '11205';
 const OTHER_AREA_CODE = '212';
-const PURCHASING_STRATEGY = 'same-state-by-distance';
+const PURCHASING_STRATEGY = 'SAME_STATE_BY_DISTANCE';
 const randomInt = Math.round(Math.random() * 1000);
 const LOCATION_REFERENCE_NAME = `TestLocation_${Date.now()}_${randomInt}`;
 

--- a/src/lib/sms/SMSClient.ts
+++ b/src/lib/sms/SMSClient.ts
@@ -15,6 +15,7 @@ export const SMS_GRAPHQL_PATH = '/sms/graphql';
 interface CreateSendingLocationInput {
   profileId: string;
   referenceName: string;
+  purchasingStrategy: string;
   center: string;
 }
 

--- a/src/lib/sms/queries.ts
+++ b/src/lib/sms/queries.ts
@@ -12,7 +12,7 @@ export const GET_SENDING_LOCATIONS = `
 `;
 
 export const CREATE_SENDING_LOCATION = `
-  mutation createSendingLocation($profileId: UUID!, $referenceName: String!, $purchasingStrategy: String!, $center: ZipCode!) {
+  mutation createSendingLocation($profileId: UUID!, $referenceName: String!, $purchasingStrategy: NumberPurchasingStrategy!, $center: ZipCode!) {
     createSendingLocation(input: { sendingLocation: { profileId: $profileId,  referenceName: $referenceName, purchasingStrategy: $purchasingStrategy, center: $center }}) {
       sendingLocation {
         areaCodes

--- a/src/lib/sms/queries.ts
+++ b/src/lib/sms/queries.ts
@@ -12,8 +12,8 @@ export const GET_SENDING_LOCATIONS = `
 `;
 
 export const CREATE_SENDING_LOCATION = `
-  mutation createSendingLocation($profileId: UUID!, $referenceName: String!, $center: ZipCode!) {
-    createSendingLocation(input: { sendingLocation: { profileId: $profileId,  referenceName: $referenceName, center: $center }}) {
+  mutation createSendingLocation($profileId: UUID!, $referenceName: String!, $purchasingStrategy: String!, $center: ZipCode!) {
+    createSendingLocation(input: { sendingLocation: { profileId: $profileId,  referenceName: $referenceName, purchasingStrategy: $purchasingStrategy, center: $center }}) {
       sendingLocation {
         areaCodes
         id


### PR DESCRIPTION
- add missing payload field for creating a sending location 
- remove tests for updating and deleting a sending location. These have operations have been disabled in production (politics-rewired/numbers#87)
- remove test for sending message. This relies on the sending location created in an earlier test having been deleted, otherwise the send message actually succeeds.