### PR TITLE
fix: handle null completedAt correctly

### DIFF
--- a/src/lib/lookup/Request.ts
+++ b/src/lib/lookup/Request.ts
@@ -113,7 +113,7 @@ class Request {
       response.body.data.requestProgress.requestProgressResult;
 
     const result: ProgressUpdate = {
-      completedAt: new Date(completedAt),
+      completedAt: completedAt !== null ? new Date(completedAt) : null,
       progress: parseFloat(progress),
     };
 
@@ -145,7 +145,7 @@ class Request {
       const pollResult = await this.poll();
       const completedAt = pollResult.completedAt;
       const progress = pollResult.progress;
-      if (completedAt != null) {
+      if (completedAt !== null) {
         this.done = true;
       }
 


### PR DESCRIPTION
`waitUntilDone()` was returning after the very first call because a `{ "createdAt": null }` response was being turned into a valid JS date:

```
$ node

> new Date("2021-07-08T00:48:39.930932");
2021-07-08T04:48:39.930Z

> new Date(null);
1970-01-01T00:00:00.000Z
```

This is consistent with the DB state for the requests in question for this client:

```
switchboard> select created_at, closed_at, completed_at
from lookup.requests
where client_id = 'REDACTED';

         created_at         │         closed_at          │        completed_at
────────────────────────────┼────────────────────────────┼────────────────────────────
 2021-06-07 23:25:36.61225  │ 2021-06-07 23:25:41.661374 │ ¤
 2021-07-05 20:59:24.162342 │ 2021-07-05 20:59:35.860141 │ ¤
```

After running `select * from lookup.request_progress('REDACTED');`:

```
switchboard> select created_at, closed_at, completed_at
from lookup.requests
where client_id = 'REDACTED';

         created_at         │         closed_at          │        completed_at
────────────────────────────┼────────────────────────────┼────────────────────────────
 2021-06-07 23:25:36.61225  │ 2021-06-07 23:25:41.661374 │ ¤
 2021-07-05 20:59:24.162342 │ 2021-07-05 20:59:35.860141 │ 2021-07-08 00:48:39.930932
```

which is consistent with the observed behavior that the client did not actually wait for the request to complete. `completed_at` is only set by the `lookup.request_progress()` function, which was not called at a point after the request had actually completed.